### PR TITLE
Use current q-version in peer-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lazy"
   ],
   "peerDependencies": {
-    "q": "~0.9.7"
+    "q": "~1.0.0"
   },
   "devDependencies": {
     "grunt": "~0.4.2",


### PR DESCRIPTION
Q 1.x.x has been released and seems to work with q-lazy. For my current project, there is a peer-dependency error.
