### PR TITLE
Use release version of Q

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lazy"
   ],
   "peerDependencies": {
-    "q": "~0.9.7"
+    "q": "^1.0.0"
   },
   "devDependencies": {
     "grunt": "~0.4.2",
@@ -29,7 +29,7 @@
     "grunt-mocha-test": "~0.8.1",
     "mocha-as-promised": "~2.0.0",
     "should": "~2.1.1",
-    "q": "~0.9.7"
+    "q": "^1.0.0"
   },
   "author": "Dmitry Bashkatov <dbashkatov@gmail.com>",
   "license": "MIT"


### PR DESCRIPTION
I wanted to use q-lazy in a node-module, but I get a peer-dependency error, since I also use q@1.4.2
